### PR TITLE
Migrate scrape.yml

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install pipenv
-        run: pip install pipenv
+        run: |
+          pip install --upgrade pip
+          pip install pipenv
       - name: Install dependencies with pipenv
         run: |
           cd TorontoLobbyistRegistry

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -44,7 +44,7 @@ jobs:
           mv TorontoLobbyistRegistry/lobbyactivity-active.xml lobbyactivity-active.xml
           mv TorontoLobbyistRegistry/lobbyactivity-closed.xml lobbyactivity-closed.xml
           mv TorontoLobbyistRegistry/lobbyist-registry-readme.xls lobbyist-registry-readme.xls
-          mv TorontoLobbyistRegistry/Open_Data_Response.json Open_Data_Response.json
+          mv TorontoLobbyistRegistry/open-data-response.json.json open-data-response.json
           rm -rf TorontoLobbyistRegistry
       - name: Commit and push if files changed
         run: |-
@@ -53,7 +53,7 @@ jobs:
           git add lobbyactivity-active.xml
           git add lobbyactivity-closed.xml
           git add lobbyist-registry-readme.xls
-          git add Open_Data_Response.json
+          git add open-data-response.json
           timestamp=$(date -u)
           git commit -m "Dowloaded: ${timestamp}: commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
           git push

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -41,10 +41,10 @@ jobs:
           cd TorontoLobbyistRegistry
           python download_and_extract.py 
           cd ..
-          cd lobbyactivity-active.xml TorontoLobbyistRegistry/lobbyactivity-active.xml 
-          cd lobbyactivity-closed.xml TorontoLobbyistRegistry/lobbyactivity-closed.xml
-          cd lobbyist-registry-readme.xls TorontoLobbyistRegistry/lobbyist-registry-readme.xls
-          cd Open_Data_Response.json TorontoLobbyistRegistry/Open_Data_Response.json
+          mv TorontoLobbyistRegistry/lobbyactivity-active.xml lobbyactivity-active.xml
+          mv TorontoLobbyistRegistry/lobbyactivity-closed.xml lobbyactivity-closed.xml
+          mv TorontoLobbyistRegistry/lobbyist-registry-readme.xls lobbyist-registry-readme.xls
+          mv TorontoLobbyistRegistry/Open_Data_Response.json Open_Data_Response.json
           rm -rf TorontoLobbyistRegistry
 
       - name: Commit and push if files changed

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,6 +1,7 @@
 name: Download, Unzip and Save Lobbyist Registry Data
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
@@ -31,11 +32,12 @@ jobs:
           source venv/bin/activate
       - name: Install dependencies
         run: |
-          source venv/bin/activate
+          cd TorontoLobbyistRegistry
           pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run Python script to download and unzip files
         run: |
+          cd TorontoLobbyistRegistry
           python download_and_extract.py 
       - name: Commit and push if files changed
         run: |-

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -51,7 +51,10 @@ jobs:
         run: |-
           git config user.name "Automated"
           git config user.email "actions@users.noreply.github.com"
-          git add -A
+          git add lobbyactivity-active.xml
+          git add lobbyactivity-closed.xml
+          git add lobbyist-registry-readme.xls
+          git add Open_Data_Response.json
           timestamp=$(date -u)
           git commit -m "Dowloaded: ${timestamp}: TorontoLobbyistRegistry commit ${TorontoLobbyistRegistry_commit_hash}" || exit 0
           git push

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout current repo
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT_TORONTOLOBBYISTREGISTRYDATA }}
       - name: Checkout TorontoLobbyistRegistry
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -42,6 +42,7 @@ jobs:
           mv TorontoLobbyistRegistry/lobbyactivity-closed.xml lobbyactivity-closed.xml
           mv TorontoLobbyistRegistry/lobbyist-registry-readme.xls lobbyist-registry-readme.xls
           mv TorontoLobbyistRegistry/open-data-response.json open-data-response.json
+          mv TorontoLobbyistRegistry/"Lobbyist Registry Activity.zip" "Lobbyist Registry Activity.zip"
           rm -rf TorontoLobbyistRegistry
       - name: Commit and push if files changed
         run: |-
@@ -51,6 +52,7 @@ jobs:
           git add lobbyactivity-closed.xml
           git add lobbyist-registry-readme.xls
           git add open-data-response.json
+          git add "Lobbyist Registry Activity.zip"
           timestamp=$(date -u)
           git commit -m "Dowloaded: ${timestamp}: commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
           git push

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -55,5 +55,5 @@ jobs:
           git add lobbyist-registry-readme.xls
           git add Open_Data_Response.json
           timestamp=$(date -u)
-          git commit -m "Dowloaded: ${timestamp}: TorontoLobbyistRegistry commit: ${env.TorontoLobbyistRegistry_commit_hash}" || exit 0
+          git commit -m "Dowloaded: ${timestamp}: TorontoLobbyistRegistry commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
           git push

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -42,6 +42,10 @@ jobs:
           cd TorontoLobbyistRegistry
           python download_and_extract.py 
           cd ..
+          cd lobbyactivity-active.xml TorontoLobbyistRegistry/lobbyactivity-active.xml 
+          cd lobbyactivity-closed.xml TorontoLobbyistRegistry/lobbyactivity-closed.xml
+          cd lobbyist-registry-readme.xls TorontoLobbyistRegistry/lobbyist-registry-readme.xls
+          cd Open_Data_Response.json TorontoLobbyistRegistry/Open_Data_Response.json
           rm -rf
       - name: Commit and push if files changed
         run: |-

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run Python script to download and unzip files
         run: |
           cd TorontoLobbyistRegistry
-          python -m download_and_extract.py 
+          python download_and_extract.py 
       - name: Commit and push if files changed
         run: |-
           git config user.name "Automated"

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -27,19 +27,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - name: Create and activate virtual environment
-        run: |
-          python -m venv venv
-          source venv/bin/activate
-      - name: Install dependencies
+      - name: Install pipenv
+        run: pip install pipenv
+      - name: Install dependencies with pipenv
         run: |
           cd TorontoLobbyistRegistry
-          pip install --upgrade pip
-          pip install -r requirements.txt
+          pipenv install
       - name: Run Python script to download and unzip files
         run: |
           cd TorontoLobbyistRegistry
-          python download_and_extract.py 
+          pipenv run python download_and_extract.py 
           cd ..
           mv TorontoLobbyistRegistry/lobbyactivity-active.xml lobbyactivity-active.xml
           mv TorontoLobbyistRegistry/lobbyactivity-closed.xml lobbyactivity-closed.xml

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,50 @@
+name: Download, Unzip and Save Lobbyist Registry Data
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  download_lobby_data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v2
+      - name: Checkout TorontoLobbyistRegistry
+        uses: actions/checkout@v2
+        with:
+          repository: 'RamVasuthevan/TorontoLobbyistRegistry'
+          token: ${{ secrets.PAT }}
+          path: TorontoLobbyistRegistry
+      - name: Echo commit hash of TorontoLobbyistRegistry
+        run: |
+          cd TorontoLobbyistRegistry
+          TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)
+          echo "Commit hash: ${TorontoLobbyistRegistry_commit_hash}"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Create and activate virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+      - name: Install dependencies
+        run: |
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Python script to download and unzip files
+        run: |
+          python download_and_extract.py 
+      - name: Commit and push if files changed
+        run: |-
+          git config user.name "Automated"
+          git config user.email "actions@users.noreply.github.com"
+          git add -A
+          timestamp=$(date -u)
+          git commit -m "Dowloaded: ${timestamp}: TorontoLobbyistRegistry commit ${TorontoLobbyistRegistry_commit_hash}" || exit 0
+          git push

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -46,7 +46,6 @@ jobs:
           mv TorontoLobbyistRegistry/lobbyist-registry-readme.xls lobbyist-registry-readme.xls
           mv TorontoLobbyistRegistry/Open_Data_Response.json Open_Data_Response.json
           rm -rf TorontoLobbyistRegistry
-
       - name: Commit and push if files changed
         run: |-
           git config user.name "Automated"

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -55,5 +55,5 @@ jobs:
           git add lobbyist-registry-readme.xls
           git add Open_Data_Response.json
           timestamp=$(date -u)
-          git commit -m "Dowloaded: ${timestamp}: TorontoLobbyistRegistry commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
+          git commit -m "Dowloaded: ${timestamp}: commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
           git push

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -45,7 +45,8 @@ jobs:
           cd lobbyactivity-closed.xml TorontoLobbyistRegistry/lobbyactivity-closed.xml
           cd lobbyist-registry-readme.xls TorontoLobbyistRegistry/lobbyist-registry-readme.xls
           cd Open_Data_Response.json TorontoLobbyistRegistry/Open_Data_Response.json
-          rm -rf
+          rm -rf TorontoLobbyistRegistry
+
       - name: Commit and push if files changed
         run: |-
           git config user.name "Automated"

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,9 +1,6 @@
 name: Download, Unzip and Save Lobbyist Registry Data
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
           cd TorontoLobbyistRegistry
           python download_and_extract.py 
+          cd ..
+          rm -rf
       - name: Commit and push if files changed
         run: |-
           git config user.name "Automated"

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,7 +1,6 @@
 name: Download, Unzip and Save Lobbyist Registry Data
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           cd TorontoLobbyistRegistry
           TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)
-          echo "Commit hash: ${TorontoLobbyistRegistry_commit_hash}"
+          echo "TorontoLobbyistRegistry_commit_hash=${TorontoLobbyistRegistry_commit_hash}" >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -55,5 +55,5 @@ jobs:
           git add lobbyist-registry-readme.xls
           git add Open_Data_Response.json
           timestamp=$(date -u)
-          git commit -m "Dowloaded: ${timestamp}: TorontoLobbyistRegistry commit ${TorontoLobbyistRegistry_commit_hash}" || exit 0
+          git commit -m "Dowloaded: ${timestamp}: TorontoLobbyistRegistry commit: ${env.TorontoLobbyistRegistry_commit_hash}" || exit 0
           git push

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run Python script to download and unzip files
         run: |
           cd TorontoLobbyistRegistry
-          python download_and_extract.py 
+          python -m download_and_extract.py 
       - name: Commit and push if files changed
         run: |-
           git config user.name "Automated"

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -44,7 +44,7 @@ jobs:
           mv TorontoLobbyistRegistry/lobbyactivity-active.xml lobbyactivity-active.xml
           mv TorontoLobbyistRegistry/lobbyactivity-closed.xml lobbyactivity-closed.xml
           mv TorontoLobbyistRegistry/lobbyist-registry-readme.xls lobbyist-registry-readme.xls
-          mv TorontoLobbyistRegistry/open-data-response.json.json open-data-response.json
+          mv TorontoLobbyistRegistry/open-data-response.json open-data-response.json
           rm -rf TorontoLobbyistRegistry
       - name: Commit and push if files changed
         run: |-

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -12,7 +12,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Echo commit hash of TorontoLobbyistRegistry
         run: |
-          echo "TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)
+          echo "TorontoLobbyistRegistry_commit_hash=${TorontoLobbyistRegistry_commit_hash}" >> $GITHUB_ENV
+          echo "TorontoLobbyistRegistry_commit_hash=${TorontoLobbyistRegistry_commit_hash}"
       - name: Checkout TorontoLobbyistRegistryData
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout TorontoLobbyistRegistryData
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT_ACTION_SCRAPE_PAT_TORONTOLOBBYISTREGISTRY }}
+          token: ${{ secrets.PAT_TORONTOLOBBYISTREGISTRY_SCRAPE }}
           path: TorontoLobbyistRegistryData
           ref: 'test'
       - name: Echo commit hash of TorontoLobbyistRegistry

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -8,14 +8,11 @@ jobs:
   download_lobby_data:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout TorontoLobbyistRegistry
+      - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          repository: 'RamVasuthevan/TorontoLobbyistRegistry'
       - name: Echo commit hash of TorontoLobbyistRegistry
         run: |
-          TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)
-          echo "TorontoLobbyistRegistry_commit_hash=${TorontoLobbyistRegistry_commit_hash}" >> $GITHUB_ENV
+          echo "TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Checkout TorontoLobbyistRegistryData
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -3,7 +3,7 @@ name: Download, Unzip and Save Lobbyist Registry Data
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '30 21 * * *'
 jobs:
   download_lobby_data:
     runs-on: ubuntu-latest

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -8,6 +8,10 @@ jobs:
   download_lobby_data:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout TorontoLobbyistRegistry
+        uses: actions/checkout@v2
+        with:
+          repository: 'RamVasuthevan/TorontoLobbyistRegistry'
       - name: Echo commit hash of TorontoLobbyistRegistry
         run: |
           TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -8,19 +8,14 @@ jobs:
   download_lobby_data:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout current repo
+      - name: Checkout TorontoLobbyistRegistryData
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT_TORONTOLOBBYISTREGISTRYDATA }}
-      - name: Checkout TorontoLobbyistRegistry
-        uses: actions/checkout@v2
-        with:
-          repository: 'RamVasuthevan/TorontoLobbyistRegistry'
-          token: ${{ secrets.PAT }}
-          path: TorontoLobbyistRegistry
+          token: ${{ secrets.PAT_ACTION_SCRAPE_PAT_TORONTOLOBBYISTREGISTRY }}
+          path: TorontoLobbyistRegistryData
+          ref: 'test'
       - name: Echo commit hash of TorontoLobbyistRegistry
         run: |
-          cd TorontoLobbyistRegistry
           TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)
           echo "TorontoLobbyistRegistry_commit_hash=${TorontoLobbyistRegistry_commit_hash}" >> $GITHUB_ENV
       - name: Set up Python
@@ -33,21 +28,19 @@ jobs:
           pip install pipenv
       - name: Install dependencies with pipenv
         run: |
-          cd TorontoLobbyistRegistry
           pipenv install
       - name: Run Python script to download and unzip files
         run: |
-          cd TorontoLobbyistRegistry
           pipenv run python download_and_extract.py 
-          cd ..
-          mv TorontoLobbyistRegistry/lobbyactivity-active.xml lobbyactivity-active.xml
-          mv TorontoLobbyistRegistry/lobbyactivity-closed.xml lobbyactivity-closed.xml
-          mv TorontoLobbyistRegistry/lobbyist-registry-readme.xls lobbyist-registry-readme.xls
-          mv TorontoLobbyistRegistry/open-data-response.json open-data-response.json
-          mv TorontoLobbyistRegistry/"Lobbyist Registry Activity.zip" "Lobbyist Registry Activity.zip"
-          rm -rf TorontoLobbyistRegistry
+          cd TorontoLobbyistRegistryData
+          mv ../lobbyactivity-active.xml lobbyactivity-active.xml
+          mv ../lobbyactivity-closed.xml lobbyactivity-closed.xml
+          mv ../lobbyist-registry-readme.xls lobbyist-registry-readme.xls
+          mv ../open-data-response.json open-data-response.json
+          mv ../"Lobbyist Registry Activity.zip" "Lobbyist Registry Activity.zip"
       - name: Commit and push if files changed
         run: |-
+          cd TorontoLobbyistRegistryData
           git config user.name "Automated"
           git config user.email "actions@users.noreply.github.com"
           git add lobbyactivity-active.xml
@@ -57,4 +50,4 @@ jobs:
           git add "Lobbyist Registry Activity.zip"
           timestamp=$(date -u)
           git commit -m "Dowloaded: ${timestamp}: commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
-          git push
+          git push origin test

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -8,6 +8,10 @@ jobs:
   download_lobby_data:
     runs-on: ubuntu-latest
     steps:
+      - name: Echo commit hash of TorontoLobbyistRegistry
+        run: |
+          TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)
+          echo "TorontoLobbyistRegistry_commit_hash=${TorontoLobbyistRegistry_commit_hash}" >> $GITHUB_ENV
       - name: Checkout TorontoLobbyistRegistryData
         uses: actions/checkout@v2
         with:
@@ -15,10 +19,6 @@ jobs:
           repository: 'RamVasuthevan/TorontoLobbyistRegistryData'
           path: TorontoLobbyistRegistryData
           ref: 'test'
-      - name: Echo commit hash of TorontoLobbyistRegistry
-        run: |
-          TorontoLobbyistRegistry_commit_hash=$(git rev-parse HEAD)
-          echo "TorontoLobbyistRegistry_commit_hash=${TorontoLobbyistRegistry_commit_hash}" >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.PAT_TORONTOLOBBYISTREGISTRY_SCRAPE }}
           repository: 'RamVasuthevan/TorontoLobbyistRegistryData'
           path: TorontoLobbyistRegistryData
-          ref: 'test'
+          ref: 'main'
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -54,4 +54,4 @@ jobs:
           git add "Lobbyist Registry Activity.zip"
           timestamp=$(date -u)
           git commit -m "Downloaded: ${timestamp}: commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
-          git push origin test
+          git push origin main

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.PAT_TORONTOLOBBYISTREGISTRY_SCRAPE }}
+          repository: 'RamVasuthevan/TorontoLobbyistRegistryData'
           path: TorontoLobbyistRegistryData
           ref: 'test'
       - name: Echo commit hash of TorontoLobbyistRegistry
@@ -49,5 +50,5 @@ jobs:
           git add open-data-response.json
           git add "Lobbyist Registry Activity.zip"
           timestamp=$(date -u)
-          git commit -m "Dowloaded: ${timestamp}: commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
+          git commit -m "Downloaded: ${timestamp}: commit: ${{env.TorontoLobbyistRegistry_commit_hash}}" || exit 0
           git push origin test


### PR DESCRIPTION
Migrated from [TorontoLobbyistRegistryData](https://github.com/RamVasuthevan/TorontoLobbyistRegistrydata)

- Remove extra round bracket
- Run on push to all branches
- cd into TorontoLobbyistRegistry
- Run python script with -m
- Remove -m
- Remove all folders to avoid being committed
- Checkout current repo with PAT
- Move files up from TorontoLobbyistRegistry
- Don't trigger on push
- Delete TorontoLobbyistRegistry
- Fix typo in move
- Only add files I need
- Fix formatting
- Set env TorontoLobbyistRegistry_commit_hash
- Fix typo in substitution
- Update commit message
- Rename Open_Data_Respone.json to open-data-response.json
- Fix typo
- Use pipenv instead for venv
- Update to save Lobbyist Registry Activity.zip
- Upgrade pipe
